### PR TITLE
Remove no effect options and correct selector

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,22 +16,14 @@ from SublimeLinter.lint import Linter, util
 class Hadolint(Linter):
     """Provides an interface to hadolint."""
 
-    syntax = 'dockerfile'
     cmd = 'hadolint'
-    executable = None
-    version_args = '-v'
-    version_re = r'Haskell Dockerfile Linter v(?P<version>\d+\.\d+)'
-    version_requirement = '>= 0.1'
     regex = r'(.+)\:(?P<line>[^\s]+) (?P<message>.+)'
     multiline = False
     line_col_base = (1, 1)
     tempfile_suffix = '-'
     error_stream = util.STREAM_BOTH
-    selectors = {}
     word_re = None
     defaults = {
-        '--ignore:,+': ''
+        '--ignore:,+': '',
+        'selector': 'source.dockerfile'
     }
-    inline_settings = ('ignore')
-    inline_overrides = None
-    comment_re = None


### PR DESCRIPTION
Remove old options which has no effect in new SublimeLinter version

```
hadolint: Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.
hadolint: Defining 'cls.selectors' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.
hadolint: Defining 'cls.version_args' has no effect. Please cleanup and remove these settings.
hadolint: Defining 'cls.version_re' has no effect. Please cleanup and remove these settings.
hadolint: Defining 'cls.version_requirement' has no effect. Please cleanup and remove these settings.
hadolint: Defining 'cls.inline_settings' has no effect. Please cleanup and remove these settings.
hadolint: Defining 'cls.inline_overrides' has no effect. Please cleanup and remove these settings.
hadolint: Defining 'cls.comment_re' has no effect. Please cleanup and remove these settings.
hadolint: Defining 'cls.executable' has no effect. Please cleanup and remove these settings.
hadolint disabled. 'selector' is mandatory in 'cls.defaults'.
 See http://www.sublimelinter.com/en/stable/linter_settings.html#selector```