### PR TITLE
Update linter.py to follow SublimeLinter evolution

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,22 +16,13 @@ from SublimeLinter.lint import Linter, util
 class Hadolint(Linter):
     """Provides an interface to hadolint."""
 
-    syntax = 'dockerfile'
     cmd = 'hadolint'
-    executable = None
-    version_args = '-v'
-    version_re = r'Haskell Dockerfile Linter v(?P<version>\d+\.\d+)'
-    version_requirement = '>= 0.1'
     regex = r'(.+)\:(?P<line>[^\s]+) (?P<message>.+)'
     multiline = False
     line_col_base = (1, 1)
     tempfile_suffix = '-'
     error_stream = util.STREAM_BOTH
-    selectors = {}
     word_re = None
     defaults = {
-        '--ignore:,+': ''
+        'selector': 'text.plain'
     }
-    inline_settings = ('ignore')
-    inline_overrides = None
-    comment_re = None


### PR DESCRIPTION
Lots of fields have been deprecated and a default value for selector is now mandatory.